### PR TITLE
Address #183 for our install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 admin/config/
 shared/config/
 public/config/
+.idea

--- a/shared/tcpdf/tcpdf.php
+++ b/shared/tcpdf/tcpdf.php
@@ -18891,12 +18891,13 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 					if (isset($tag['height'])) {
 						$ih = $this->getHTMLUnitToUnits($tag['height'], ($tag['fontsize'] / $this->k), 'px', false);
 					}
+					$filepath=K_PATH_CACHE . end(explode($tag['attribute']['src'],'/'));
 					if (($type == 'eps') OR ($type == 'ai')) {
-						$this->ImageEps($tag['attribute']['src'], $xpos, $this->y, $iw, $ih, $imglink, true, $align, '', $border, true);
+						$this->ImageEps($filepath, $xpos, $this->y, $iw, $ih, $imglink, true, $align, '', $border, true);
 					} elseif ($type == 'svg') {
-						$this->ImageSVG($tag['attribute']['src'], $xpos, $this->y, $iw, $ih, $imglink, $align, '', $border, true);
+						$this->ImageSVG($filepath, $xpos, $this->y, $iw, $ih, $imglink, $align, '', $border, true);
 					} else {
-						$this->Image($tag['attribute']['src'], $xpos, $this->y, $iw, $ih, '', $imglink, $align, false, 300, '', false, false, $border, false, false, true);
+						$this->Image($filepath, $xpos, $this->y, $iw, $ih, '', $imglink, $align, false, 300, '', false, false, $border, false, false, true);
 					}
 					switch($align) {
 						case 'T': {

--- a/shared/tcpdf/tcpdf.php
+++ b/shared/tcpdf/tcpdf.php
@@ -18891,7 +18891,8 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 					if (isset($tag['height'])) {
 						$ih = $this->getHTMLUnitToUnits($tag['height'], ($tag['fontsize'] / $this->k), 'px', false);
 					}
-					$filepath=K_PATH_CACHE . end(explode($tag['attribute']['src'],'/'));
+					$filename = explode('/', $tag['attribute']['src']);
+					$filepath = K_PATH_CACHE . end($filename);
 					if (($type == 'eps') OR ($type == 'ai')) {
 						$this->ImageEps($filepath, $xpos, $this->y, $iw, $ih, $imglink, true, $align, '', $border, true);
 					} elseif ($type == 'svg') {


### PR DESCRIPTION
The HTML to PDF code tries to use image src tags as if they are filesystem paths. My change to tcpdf.php addresses that for our installation. At best, this is a kludgey solution, but it works for us.

I also added the Jetbrains .idea folder to .gitignore because that's what I work in. Don't want to muddy your tree with my IDE mess.