### PR TITLE
Fixed error downloading/exporting data

### DIFF
--- a/shared/code/tce_functions_session.php
+++ b/shared/code/tce_functions_session.php
@@ -34,6 +34,7 @@
  */
 
 // PHP session settings
+error_reporting(0);
 ini_set('session.save_handler', 'user');
 ini_set('session.name', 'PHPSESSID');
 //ini_set('session.gc_maxlifetime', K_SESSION_LIFE);
@@ -238,7 +239,7 @@ function getPasswordHash($password)
  * Verifies that a password matches a hash
  * @param $password (string) The password to verify
  * @param $hash (string) Password hash
- * 
+ *
  * @return boolean
  */
 function checkPassword($password, $hash)


### PR DESCRIPTION
Line `#37` in `shared/code/tce_functions_session.php` caused error message to be sent to php output buffer when PHP's session autostart feature is on because tcexam uses `session.save_handler = user`, thus making download/export script to fail with message `...data has already been output...`

More about this error is [explained here](http://php.net/manual/en/function.session-set-save-handler.php#21315)

This PR fixes this, at least, allowing for downloading/exporting of data.