### PR TITLE
Ensure return value is boolean

### DIFF
--- a/shared/code/tce_functions_session.php
+++ b/shared/code/tce_functions_session.php
@@ -128,7 +128,7 @@ function F_session_write($key, $val)
 				\''.$val.'\'
 				)';
         }
-        return F_db_query($sqlup, $db);
+        return F_db_query($sqlup, $db) ? true : false;
     }
     return false;
 }


### PR DESCRIPTION
pq_query() will return a database resource on success, but the session
write function must apparently return proper boolean values.

This resolves #295