### PR TITLE
Improve speed when executing test

### DIFF
--- a/shared/code/tce_functions_test.php
+++ b/shared/code/tce_functions_test.php
@@ -827,24 +827,22 @@ function F_addLogAnswers($testlog_id, $answers_ids)
     global $db, $l;
     $testlog_id = intval($testlog_id);
     $i = 0;
+    $answer_data = array();		
     foreach ($answers_ids as $key => $answid) {
         $i++;
-        $sqli = 'INSERT INTO '.K_TABLE_LOG_ANSWER.' (
+	$answer_data[] = '('.$testlog_id.', '.$answid.', -1, '.$i.')';    
+    }
+    $answer_data_value = implode(', ', $answer_data);	
+    $sqli = 'INSERT INTO '.K_TABLE_LOG_ANSWER.' (
 			logansw_testlog_id,
 			logansw_answer_id,
 			logansw_selected,
 			logansw_order
-			) VALUES (
-			'.$testlog_id.',
-			'.$answid.',
-			-1,
-			'.$i.'
-			)';
-        if (!$ri = F_db_query($sqli, $db)) {
-            F_display_db_error(false);
-            return false;
-        }
-    }
+			) VALUES '.$answer_data_value;
+    if (!$ri = F_db_query($sqli, $db)) {
+        F_display_db_error(false);
+        return false;
+    }	
     return true;
 }
 


### PR DESCRIPTION
Improving exam speed execution a little bit faster, by populating answer's data into an array, then insert it together. Very useful when we take the exam for many users at once to minimize delay #164 