### PR TITLE
fix warning on php 7.2 or above

### DIFF
--- a/admin/code/tce_import_questions.php
+++ b/admin/code/tce_import_questions.php
@@ -324,7 +324,7 @@ function F_TSVQuestionImporter($tsvfile)
                     if ($m = F_db_fetch_array($r)) {
                         // get existing question ID
                         $current_question_id = $m['question_id'];
-                        continue;
+                        continue 2;
                     }
                 } else {
                     F_display_db_error();


### PR DESCRIPTION
fix warning : "continue" targeting switch is equivalent to "break" on php 7.2 or above